### PR TITLE
namespace package compat w/ recent setuptools; works around poor choi…

### DIFF
--- a/uu/__init__.py
+++ b/uu/__init__.py
@@ -1,5 +1,5 @@
 try:
     __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
+except:
     from pkgutil import extend_path
     __path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
…ce of namespace (collision)... Needed to make uu.\* packages compatible with most recent setuptools (because 'uu' collides with a std lib package; the bare except is crude, but works).
